### PR TITLE
add allowedHostPaths configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,27 +8,33 @@ SecurityProfile
 
 SecurityProfile has these fields:
 
-| Name                     | Type        | Description                                                                                                                                 |
-| ------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| name                     | string      | The name of the profile                                                                                                                     |
-| hostNamespace            | bool        | Allow sharing the host namespaces                                                                                                           |
-| privileged               | bool        | Allow privileged containers                                                                                                                 |
-| capabilities             | bool        | Allow adding capabilities beyond the [default set](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities). |
-| additionalCapabilities   | []string    | The list of capabilities that cab be added. If `capabilities` is true, this list will be ignored.                                           |
-| hostPathVolumes          | bool        | Allow usage of HostPath volumes                                                                                                             |
-| nonCoreVolumeTypes       | bool        | Allow usage of non-core volume types                                                                                                        |
-| hostPorts                | bool        | Allow usage of all HostPorts                                                                                                                |
-| allowedHostPorts         | []PortRange | The list of host ports that can be used. If `hostPorts` is true, this list will be ignored.                                                 |
-| appArmor                 | bool        | Allow overriding or disabling the default AppArmor profile                                                                                  |
-| seLinux                  | bool        | Allow setting custom SELinux options                                                                                                        |
-| procMount                | bool        | Allow unmasked proc mount                                                                                                                   |
-| sysctls                  | bool        | Allow usage of unsafe sysctls                                                                                                               |
-| allowPrivilegeEscalation | bool        | Allow privilege escalation                                                                                                                  |
-| runAsRoot                | bool        | Allow running as root users                                                                                                                 |
-| forceRunAsNonRoot        | bool        | Force running with non-root users by MutatingWebhook                                                                                        |
-| rootGroups               | bool        | Allow running with a root primary or supplementary GID                                                                                      |
-| seccomp                  | bool        | Allow usage of non-default Seccomp profile                                                                                                  |
+| Name                     | Type              | Description                                                                                                                                 |
+| ------------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| name                     | string            | The name of the profile                                                                                                                     |
+| hostNamespace            | bool              | Allow sharing the host namespaces                                                                                                           |
+| privileged               | bool              | Allow privileged containers                                                                                                                 |
+| capabilities             | bool              | Allow adding capabilities beyond the [default set](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities). |
+| additionalCapabilities   | []string          | The list of capabilities that cab be added. If `capabilities` is true, this list will be ignored.                                           |
+| hostPathVolumes          | bool              | Allow usage of HostPath volumes                                                                                                             |
+| allowedHostPaths         | []AllowedHostPath | The list of host paths that can be used. If `hostPathVolumes` is true, this list will be ignored.                                           |
+| nonCoreVolumeTypes       | bool              | Allow usage of non-core volume types, except HostPath volumes                                                                               |
+| hostPorts                | bool              | Allow usage of all HostPorts                                                                                                                |
+| allowedHostPorts         | []PortRange       | The list of host ports that can be used. If `hostPorts` is true, this list will be ignored.                                                 |
+| appArmor                 | bool              | Allow overriding or disabling the default AppArmor profile                                                                                  |
+| seLinux                  | bool              | Allow setting custom SELinux options                                                                                                        |
+| procMount                | bool              | Allow unmasked proc mount                                                                                                                   |
+| sysctls                  | bool              | Allow usage of unsafe sysctls                                                                                                               |
+| allowPrivilegeEscalation | bool              | Allow privilege escalation                                                                                                                  |
+| runAsRoot                | bool              | Allow running as root users                                                                                                                 |
+| forceRunAsNonRoot        | bool              | Force running with non-root users by MutatingWebhook                                                                                        |
+| rootGroups               | bool              | Allow running with a root primary or supplementary GID                                                                                      |
+| seccomp                  | bool              | Allow usage of non-default Seccomp profile                                                                                                  |
 
+#### AllowedHostPath
+
+| Name       | Type   | Description                   |
+| ---------- | ------ | ----------------------------- |
+| pathPrefix | string | The path prefix to be allowed |
 
 ### PortRange
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ SecurityProfile has these fields:
 | privileged               | bool              | Allow privileged containers                                                                                                                 |
 | capabilities             | bool              | Allow adding capabilities beyond the [default set](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities). |
 | additionalCapabilities   | []string          | The list of capabilities that cab be added. If `capabilities` is true, this list will be ignored.                                           |
-| hostPathVolumes          | bool              | Allow usage of HostPath volumes                                                                                                             |
+| hostPathVolumes          | bool              | Allow usage of all HostPath volumes                                                                                                         |
 | allowedHostPaths         | []AllowedHostPath | The list of host paths that can be used. If `hostPathVolumes` is true, this list will be ignored.                                           |
 | nonCoreVolumeTypes       | bool              | Allow usage of non-core volume types, except HostPath volumes                                                                               |
 | hostPorts                | bool              | Allow usage of all HostPorts                                                                                                                |

--- a/hooks/config.go
+++ b/hooks/config.go
@@ -6,21 +6,22 @@ import "github.com/cybozu-go/pod-security-admission/hooks/validators"
 type SecurityProfile struct {
 	Name string `json:"name"`
 
-	HostNamespace            bool                   `json:"hostNamespace"`
-	Privileged               bool                   `json:"privileged"`
-	Capabilities             bool                   `json:"capabilities"`
-	AdditionalCapabilities   []string               `json:"additionalCapabilities"`
-	HostPathVolumes          bool                   `json:"hostPathVolumes"`
-	NonCoreVolumeTypes       bool                   `json:"nonCoreVolumeTypes"`
-	HostPorts                bool                   `json:"hostPorts"`
-	AllowedHostPorts         []validators.PortRange `json:"allowedHostPorts"`
-	AppArmor                 bool                   `json:"appArmor"`
-	SELinux                  bool                   `json:"seLinux"`
-	ProcMount                bool                   `json:"procMount"`
-	Sysctls                  bool                   `json:"sysctls"`
-	AllowPrivilegeEscalation bool                   `json:"allowPrivilegeEscalation"`
-	RunAsRoot                bool                   `json:"runAsRoot"`
-	ForceRunAsNonRoot        bool                   `json:"forceRunAsNonRoot"`
-	RootGroups               bool                   `json:"rootGroups"`
-	Seccomp                  bool                   `json:"seccomp"`
+	HostNamespace            bool                         `json:"hostNamespace"`
+	Privileged               bool                         `json:"privileged"`
+	Capabilities             bool                         `json:"capabilities"`
+	AdditionalCapabilities   []string                     `json:"additionalCapabilities"`
+	HostPathVolumes          bool                         `json:"hostPathVolumes"`
+	AllowedHostPaths         []validators.AllowedHostPath `json:"allowedHostPaths"`
+	NonCoreVolumeTypes       bool                         `json:"nonCoreVolumeTypes"`
+	HostPorts                bool                         `json:"hostPorts"`
+	AllowedHostPorts         []validators.PortRange       `json:"allowedHostPorts"`
+	AppArmor                 bool                         `json:"appArmor"`
+	SELinux                  bool                         `json:"seLinux"`
+	ProcMount                bool                         `json:"procMount"`
+	Sysctls                  bool                         `json:"sysctls"`
+	AllowPrivilegeEscalation bool                         `json:"allowPrivilegeEscalation"`
+	RunAsRoot                bool                         `json:"runAsRoot"`
+	ForceRunAsNonRoot        bool                         `json:"forceRunAsNonRoot"`
+	RootGroups               bool                         `json:"rootGroups"`
+	Seccomp                  bool                         `json:"seccomp"`
 }

--- a/hooks/testdata/config/hooks.yaml
+++ b/hooks/testdata/config/hooks.yaml
@@ -1,0 +1,172 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+  - name: baseline.mpod.kb.io
+    admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: webhook-service
+        namespace: system
+        path: /mutate-baseline
+    failurePolicy: Fail
+    reinvocationPolicy: IfNeeded
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+    namespaceSelector:
+      matchExpressions:
+        - key: pod-security.cybozu.com/policy
+          operator: NotIn
+          values:
+            - "privileged"
+            - "hostpath"
+  - name: hostpath.mpod.kb.io
+    admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: webhook-service
+        namespace: system
+        path: /mutate-hostpath
+    failurePolicy: Fail
+    reinvocationPolicy: IfNeeded
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+    namespaceSelector:
+      matchExpressions:
+        - key: pod-security.cybozu.com/policy
+          operator: In
+          values:
+            - "hostpath"
+  - name: restricted.mpod.kb.io
+    admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: webhook-service
+        namespace: system
+        path: /mutate-restricted
+    failurePolicy: Fail
+    reinvocationPolicy: IfNeeded
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+    namespaceSelector:
+      matchExpressions:
+        - key: pod-security.cybozu.com/policy
+          operator: In
+          values:
+            - "restricted"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+  - name: baseline.vpod.kb.io
+    admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: webhook-service
+        namespace: system
+        path: /validate-baseline
+    failurePolicy: Fail
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+    namespaceSelector:
+      matchExpressions:
+        - key: pod-security.cybozu.com/policy
+          operator: NotIn
+          values:
+            - "privileged"
+            - "hostpath"
+  - name: hostpath.vpod.kb.io
+    admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: webhook-service
+        namespace: system
+        path: /validate-hostpath
+    failurePolicy: Fail
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+    namespaceSelector:
+      matchExpressions:
+        - key: pod-security.cybozu.com/policy
+          operator: In
+          values:
+            - "hostpath"
+  - name: restricted.vpod.kb.io
+    admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: webhook-service
+        namespace: system
+        path: /validate-restricted
+    failurePolicy: Fail
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+    namespaceSelector:
+      matchExpressions:
+        - key: pod-security.cybozu.com/policy
+          operator: In
+          values:
+            - "restricted"

--- a/hooks/testdata/hostpath/host-path3.yaml
+++ b/hooks/testdata/hostpath/host-path3.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: host-path
+  name: host-path3
   annotations:
     test.pod-security.cybozu.com/message: "denied the request: spec.volumes[0]: Forbidden: HostPath is not allowed to be used"
 spec:
@@ -13,4 +13,4 @@ spec:
   volumes:
     - name: host
       hostPath:
-        path: /etc/host
+        path: /etc/hos/subdir

--- a/hooks/testdata/hostpath/host-path4.yaml
+++ b/hooks/testdata/hostpath/host-path4.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: host-path
+  name: host-path4
   annotations:
     test.pod-security.cybozu.com/message: "denied the request: spec.volumes[0]: Forbidden: HostPath is not allowed to be used"
 spec:
@@ -13,4 +13,4 @@ spec:
   volumes:
     - name: host
       hostPath:
-        path: /etc/host
+        path: /etc/hos

--- a/hooks/testdata/namespace/hostpath.yaml
+++ b/hooks/testdata/namespace/hostpath.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hostpath
+  labels:
+    pod-security.cybozu.com/policy: hostpath

--- a/hooks/testdata/privileged/host-path2.yaml
+++ b/hooks/testdata/privileged/host-path2.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: host-path
+  name: host-path2
   annotations:
     test.pod-security.cybozu.com/message: "denied the request: spec.volumes[0]: Forbidden: HostPath is not allowed to be used"
 spec:
@@ -13,4 +13,4 @@ spec:
   volumes:
     - name: host
       hostPath:
-        path: /etc/host
+        path: /not/allowed/by/policy

--- a/hooks/validate_pod.go
+++ b/hooks/validate_pod.go
@@ -46,7 +46,7 @@ func createValidators(prof SecurityProfile) []validators.Validator {
 		list = append(list, validators.NewDenyUnsafeCapabilities(prof.AdditionalCapabilities))
 	}
 	if !prof.HostPathVolumes {
-		list = append(list, validators.DenyHostPathVolumes{})
+		list = append(list, validators.NewDenyHostPaths(prof.AllowedHostPaths))
 	}
 	if !prof.HostPorts {
 		list = append(list, validators.NewDenyHostPorts(prof.AllowedHostPorts))

--- a/hooks/validate_pod_test.go
+++ b/hooks/validate_pod_test.go
@@ -40,18 +40,28 @@ func validatePod(dir string, namespace string, allowed bool) {
 var _ = Describe("validate Pod webhook", func() {
 	It("should allow all pods in privileged namespace", func() {
 		validatePod(filepath.Join("testdata", "privileged"), "privileged", true)
+		validatePod(filepath.Join("testdata", "hostpath"), "privileged", true)
 		validatePod(filepath.Join("testdata", "baseline"), "privileged", true)
 		validatePod(filepath.Join("testdata", "restricted"), "privileged", true)
 	})
 
-	It("should deny privileged pods in baseline namespace", func() {
+	It("should deny privileged pods in hostpath namespace", func() {
+		validatePod(filepath.Join("testdata", "privileged"), "hostpath", false)
+		validatePod(filepath.Join("testdata", "hostpath"), "hostpath", true)
+		validatePod(filepath.Join("testdata", "baseline"), "hostpath", true)
+		validatePod(filepath.Join("testdata", "restricted"), "hostpath", true)
+	})
+
+	It("should deny privileged and hostpath pods in baseline namespace", func() {
 		validatePod(filepath.Join("testdata", "privileged"), "baseline", false)
+		validatePod(filepath.Join("testdata", "hostpath"), "baseline", false)
 		validatePod(filepath.Join("testdata", "baseline"), "baseline", true)
 		validatePod(filepath.Join("testdata", "restricted"), "baseline", true)
 	})
 
-	It("should deny privileged and baseline pods in restricted namespace", func() {
+	It("should deny privileged, hostpath, and baseline pods in restricted namespace", func() {
 		validatePod(filepath.Join("testdata", "privileged"), "restricted", false)
+		validatePod(filepath.Join("testdata", "hostpath"), "restricted", false)
 		validatePod(filepath.Join("testdata", "baseline"), "restricted", false)
 		validatePod(filepath.Join("testdata", "restricted"), "restricted", true)
 	})

--- a/hooks/validators/deny_host_path_volumes.go
+++ b/hooks/validators/deny_host_path_volumes.go
@@ -31,17 +31,13 @@ volume_for:
 		if vol.HostPath == nil {
 			continue
 		}
-		if v.allowedHostPaths == nil {
-			errs = append(errs, field.Forbidden(p.Index(i), "HostPath is not allowed to be used"))
-		} else {
-			pathstr := vol.HostPath.Path
-			for _, allowed := range v.allowedHostPaths {
-				if strings.HasPrefix(pathstr, allowed.PathPrefix) && (len(pathstr) == len(allowed.PathPrefix) || []rune(pathstr)[len(allowed.PathPrefix)] == filepath.Separator) {
-					continue volume_for
-				}
+		pathstr := vol.HostPath.Path
+		for _, allowed := range v.allowedHostPaths {
+			if strings.HasPrefix(pathstr, allowed.PathPrefix) && (len(pathstr) == len(allowed.PathPrefix) || []rune(pathstr)[len(allowed.PathPrefix)] == filepath.Separator) {
+				continue volume_for
 			}
-			errs = append(errs, field.Forbidden(p.Index(i), "HostPath is not allowed to be used"))
 		}
+		errs = append(errs, field.Forbidden(p.Index(i), "HostPath is not allowed to be used"))
 	}
 	return errs
 }

--- a/hooks/validators/deny_host_path_volumes.go
+++ b/hooks/validators/deny_host_path_volumes.go
@@ -2,23 +2,45 @@ package validators
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+type AllowedHostPath struct {
+	PathPrefix string `json:"pathPrefix"`
+}
+
 // DenyHostPathVolumes is a Validator that denies usage of HostPath volumes
-type DenyHostPathVolumes struct{}
+type DenyHostPathVolumes struct {
+	allowedHostPaths []AllowedHostPath
+}
+
+func NewDenyHostPaths(hostPaths []AllowedHostPath) DenyHostPathVolumes {
+	return DenyHostPathVolumes{allowedHostPaths: hostPaths}
+}
 
 func (v DenyHostPathVolumes) Validate(ctx context.Context, pod *corev1.Pod) field.ErrorList {
 	p := field.NewPath("spec").Child("volumes")
 	var errs field.ErrorList
+
+volume_for:
 	for i, vol := range pod.Spec.Volumes {
 		if vol.HostPath == nil {
 			continue
 		}
-		if len(vol.HostPath.Path) != 0 || vol.HostPath.Type != nil {
-			errs = append(errs, field.Forbidden(p.Index(i), "Volume type HostPath is not allowed to be used"))
+		if v.allowedHostPaths == nil {
+			errs = append(errs, field.Forbidden(p.Index(i), "HostPath is not allowed to be used"))
+		} else {
+			pathstr := vol.HostPath.Path
+			for _, allowed := range v.allowedHostPaths {
+				if strings.HasPrefix(pathstr, allowed.PathPrefix) && (len(pathstr) == len(allowed.PathPrefix) || []rune(pathstr)[len(allowed.PathPrefix)] == filepath.Separator) {
+					continue volume_for
+				}
+			}
+			errs = append(errs, field.Forbidden(p.Index(i), "HostPath is not allowed to be used"))
 		}
 	}
 	return errs

--- a/hooks/validators/deny_non_core_volume_types.go
+++ b/hooks/validators/deny_non_core_volume_types.go
@@ -15,9 +15,6 @@ func (v DenyNonCoreVolumeTypes) Validate(ctx context.Context, pod *corev1.Pod) f
 	var errs field.ErrorList
 
 	for i, vol := range pod.Spec.Volumes {
-		if vol.HostPath != nil {
-			errs = append(errs, field.Forbidden(p.Index(i), "Volume type HostPath is not allowed to be used"))
-		}
 		if vol.GCEPersistentDisk != nil {
 			errs = append(errs, field.Forbidden(p.Index(i), "Volume type GCEPersistentDisk is not allowed to be used"))
 		}


### PR DESCRIPTION
also part of https://github.com/cybozu-go/neco/issues/1694

Add `allowedHostPaths`, which allows specific hostPath prefixes.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>