### PR TITLE
Support for Ephemeral Container

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ Documentation
 
 [docs](docs/) directory contains documents about designs and specifications.
 
+Limitations
+-----------
+
+The following webhooks do not work.
+- Validating Webhook to deny an ephemeral container from running as root user.
+- Mutating Webhook to force an ephemeral container to run as non-root user.
+
+This is because `kubectl debug` command can not specify a user to run ephemeral containers.
+
+We have to wait until the following Issue is completed:
+https://github.com/kubernetes/kubectl/issues/1108
+
 Docker images
 -------------
 

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ Documentation
 Limitations
 -----------
 
-The following webhooks do not work.
-- Validating Webhook to deny an ephemeral container from running as root user.
-- Mutating Webhook to force an ephemeral container to run as non-root user.
+The behavior of the webhooks are restricted intentionally as follows:
+- Validating Webhook does not deny an ephemeral container from running as root user.
+- Mutating Webhook does not force an ephemeral container to run as non-root user.
 
-This is because `kubectl debug` command can not specify a user to run ephemeral containers.
+This is because `kubectl debug` command cannot specify a user to run ephemeral containers.
 
 We have to wait until the following Issue is completed:
 https://github.com/kubernetes/kubectl/issues/1108

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -25,6 +25,14 @@ webhooks:
           - CREATE
         resources:
           - pods
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - pods/ephemeralcontainers
     sideEffects: None
     namespaceSelector:
       matchExpressions:
@@ -52,6 +60,14 @@ webhooks:
           - CREATE
         resources:
           - pods
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - pods/ephemeralcontainers
     sideEffects: None
     namespaceSelector:
       matchExpressions:
@@ -85,6 +101,14 @@ webhooks:
           - CREATE
         resources:
           - pods
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - pods/ephemeralcontainers
     sideEffects: None
     namespaceSelector:
       matchExpressions:
@@ -111,6 +135,14 @@ webhooks:
           - CREATE
         resources:
           - pods
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - pods/ephemeralcontainers
     sideEffects: None
     namespaceSelector:
       matchExpressions:

--- a/hooks/ephemeral_container_test.go
+++ b/hooks/ephemeral_container_test.go
@@ -72,7 +72,7 @@ spec:
 					Privileged:   pointer.Bool(true),
 				},
 			},
-		}, false, "denied the request: spec.ephemeralContainer[0].securityContext.privileged: Forbidden: Privileged containers are not allowed"),
+		}, false, "denied the request: spec.ephemeralContainers[0].securityContext.privileged: Forbidden: Privileged containers are not allowed"),
 		Entry("AllowPrivilegeEscalation Ephemeral Container", "restricted", "test-allow-privilege-escalation-ec", corev1.EphemeralContainer{
 			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
 				Name:  "debug",

--- a/hooks/ephemeral_container_test.go
+++ b/hooks/ephemeral_container_test.go
@@ -199,10 +199,10 @@ spec:
 					ret := &corev1.Pod{}
 					err = k8sClient.Get(testCtx, types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}, ret)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(pod.Spec.EphemeralContainers).Should(HaveLen(1))
-					Expect(pod.Spec.EphemeralContainers[0].SecurityContext).ShouldNot(BeNil())
-					Expect(pod.Spec.EphemeralContainers[0].SecurityContext.RunAsNonRoot).ShouldNot(BeNil())
-					Expect(pod.Spec.EphemeralContainers[0].SecurityContext.RunAsNonRoot).ShouldNot(HaveValue(Equal(true)))
+					Expect(ret.Spec.EphemeralContainers).Should(HaveLen(1))
+					Expect(ret.Spec.EphemeralContainers[0].SecurityContext).ShouldNot(BeNil())
+					Expect(ret.Spec.EphemeralContainers[0].SecurityContext.RunAsNonRoot).ShouldNot(BeNil())
+					Expect(ret.Spec.EphemeralContainers[0].SecurityContext.RunAsNonRoot).ShouldNot(HaveValue(Equal(true)))
 				})
 			})
 	*/

--- a/hooks/ephemeral_container_test.go
+++ b/hooks/ephemeral_container_test.go
@@ -1,0 +1,209 @@
+package hooks
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("Admission Webhook for EphemeralContainer", func() {
+
+	unmasked := corev1.UnmaskedProcMount
+	DescribeTable("Validating Ephemeral Container", func(namespace, name string, ec corev1.EphemeralContainer, allowed bool, message string) {
+		podManifest := `apiVersion: v1
+kind: Pod
+metadata:
+  namespace: %s
+  name: %s
+spec:
+  containers:
+  - name: ubuntu
+    image: quay.io/cybozu/ubuntu
+    securityContext:
+      runAsNonRoot: true
+`
+
+		pod := &corev1.Pod{}
+		d := yaml.NewYAMLOrJSONDecoder(strings.NewReader(fmt.Sprintf(podManifest, namespace, name)), 4096)
+		err := d.Decode(pod)
+		Expect(err).NotTo(HaveOccurred())
+		err = k8sClient.Create(testCtx, pod)
+		Expect(err).NotTo(HaveOccurred())
+
+		k8s, err := kubernetes.NewForConfig(k8sConfig)
+		Expect(err).NotTo(HaveOccurred())
+		podClient := k8s.CoreV1().Pods(pod.Namespace)
+		pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, ec)
+
+		_, err = podClient.UpdateEphemeralContainers(testCtx, pod.Name, pod, metav1.UpdateOptions{})
+		if allowed {
+			Expect(err).NotTo(HaveOccurred(), "pod: %v", pod)
+		} else {
+			Expect(err).To(HaveOccurred(), "pod: %v", pod)
+			statusErr := &k8serrors.StatusError{}
+			Expect(errors.As(err, &statusErr)).To(BeTrue())
+			Expect(statusErr.ErrStatus.Message).To(ContainSubstring(message))
+		}
+	},
+		Entry("Valid Ephemeral Container", "restricted", "test-simple-ec", corev1.EphemeralContainer{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:  "debug",
+				Image: "quay.io/cybozu/ubuntu-debug",
+				SecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot: pointer.Bool(true),
+				},
+			},
+		}, true, ""),
+		Entry("Privileged Ephemeral Container", "baseline", "test-privileged-ec", corev1.EphemeralContainer{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:  "debug",
+				Image: "quay.io/cybozu/ubuntu-debug",
+				SecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot: pointer.Bool(true),
+					Privileged:   pointer.Bool(true),
+				},
+			},
+		}, false, "denied the request: spec.ephemeralContainer[0].securityContext.privileged: Forbidden: Privileged containers are not allowed"),
+		Entry("AllowPrivilegeEscalation Ephemeral Container", "restricted", "test-allow-privilege-escalation-ec", corev1.EphemeralContainer{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:  "debug",
+				Image: "quay.io/cybozu/ubuntu-debug",
+				SecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot:             pointer.Bool(true),
+					AllowPrivilegeEscalation: pointer.Bool(true),
+				},
+			},
+		}, false, "denied the request: spec.ephemeralContainers[0].securityContext.allowPrivilegeEscalation: Forbidden: Allowing privilege escalation for containers is not allowed"),
+		Entry("RootGroup Ephemeral Container", "restricted", "test-root-group-ec", corev1.EphemeralContainer{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:  "debug",
+				Image: "quay.io/cybozu/ubuntu-debug",
+				SecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot: pointer.Bool(true),
+					RunAsGroup:   pointer.Int64(0),
+				},
+			},
+		}, false, "denied the request: spec.ephemeralContainers[0].securityContext.runAsGroup: Forbidden: Running with the root GID is forbidden"),
+		// runAsNonRoot of an ephemeral container will not be validated until the following issue is completed.
+		// https://github.com/kubernetes/kubectl/issues/1108
+		/*
+			Entry("RunAsRoot Ephemeral Container", "restricted", "test-run-as-root-ec", corev1.EphemeralContainer{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name:  "debug",
+					Image: "quay.io/cybozu/ubuntu-debug",
+					SecurityContext: &corev1.SecurityContext{
+						RunAsNonRoot: pointer.Bool(false),
+					},
+				},
+			}, false, "denied the request: [spec.ephemeralContainers[0].securityContext.runAsNonRoot: Forbidden: RunAsNonRoot must be true, spec.securityContext: Forbidden: RunAsNonRoot must be true]"),
+		*/
+		Entry("UnsafeCapability Ephemeral Container", "restricted", "test-unsafe-capability-ec", corev1.EphemeralContainer{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:  "debug",
+				Image: "quay.io/cybozu/ubuntu-debug",
+				SecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot: pointer.Bool(true),
+					Capabilities: &corev1.Capabilities{
+						Add: []corev1.Capability{
+							"SYSLOG",
+						},
+					},
+				},
+			},
+		}, false, "denied the request: spec.ephemeralContainers[0].securityContext.capabilities.add[0]: Forbidden: Adding capability SYSLOG is not allowed"),
+		Entry("UnsafeProcMount Ephemeral Container", "restricted", "test-unsafe-procmount-ec", corev1.EphemeralContainer{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:  "debug",
+				Image: "quay.io/cybozu/ubuntu-debug",
+				SecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot: pointer.Bool(true),
+					ProcMount:    &unmasked,
+				},
+			},
+		}, false, "denied the request: spec.ephemeralContainers[0].securityContext.procMount: Forbidden: ProcMountType Unmasked is not allowed"),
+		Entry("UnsafeSeccomp Ephemeral Container", "restricted", "test-unsafe-seccomp-ec", corev1.EphemeralContainer{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:  "debug",
+				Image: "quay.io/cybozu/ubuntu-debug",
+				SecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot: pointer.Bool(true),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type:             corev1.SeccompProfileTypeLocalhost,
+						LocalhostProfile: pointer.String("profiles/audit.json"),
+					},
+				},
+			},
+		}, false, "denied the request: spec.ephemeralContainers[0].securityContext.seccompProfile.type: Forbidden: Localhost is not an allowed seccomp profile"),
+		Entry("UnsafeSELinux Ephemeral Container", "restricted", "test-unsafe-selinux-ec", corev1.EphemeralContainer{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:  "debug",
+				Image: "quay.io/cybozu/ubuntu-debug",
+				SecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot: pointer.Bool(true),
+					SELinuxOptions: &corev1.SELinuxOptions{
+						Level: "s0:c123,c456",
+					},
+				},
+			},
+		}, false, "denied the request: spec.ephemeralContainers[0].securityContext.selinuxOptions: Forbidden: Setting custom SELinux options is not allowed"),
+	)
+
+	// runAsNonRoot of an ephemeral container will not be mutated until the following issue is completed.
+	// https://github.com/kubernetes/kubectl/issues/1108
+	/*
+			Context("Mutating EphemeralContainer", func() {
+				It("", func() {
+					podManifest := `apiVersion: v1
+		kind: Pod
+		metadata:
+		  namespace: %s
+		  name: %s
+		spec:
+		  containers:
+		  - name: ubuntu
+		    image: quay.io/cybozu/ubuntu
+		    securityContext:
+		      runAsNonRoot: true
+		`
+
+					pod := &corev1.Pod{}
+					d := yaml.NewYAMLOrJSONDecoder(strings.NewReader(fmt.Sprintf(podManifest, "mutating", "test-mutate-ec")), 4096)
+					err := d.Decode(pod)
+					Expect(err).NotTo(HaveOccurred())
+					err = k8sClient.Create(testCtx, pod)
+					Expect(err).NotTo(HaveOccurred())
+
+					k8s, err := kubernetes.NewForConfig(k8sConfig)
+					Expect(err).NotTo(HaveOccurred())
+					podClient := k8s.CoreV1().Pods(pod.Namespace)
+					ec := corev1.EphemeralContainer{
+						EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+							Name:  "debug",
+							Image: "quay.io/cybozu/ubuntu-debug",
+						},
+					}
+					pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, ec)
+
+					_, err = podClient.UpdateEphemeralContainers(testCtx, pod.Name, pod, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred(), "pod: %v", pod)
+
+					ret := &corev1.Pod{}
+					err = k8sClient.Get(testCtx, types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}, ret)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(pod.Spec.EphemeralContainers).Should(HaveLen(1))
+					Expect(pod.Spec.EphemeralContainers[0].SecurityContext).ShouldNot(BeNil())
+					Expect(pod.Spec.EphemeralContainers[0].SecurityContext.RunAsNonRoot).ShouldNot(BeNil())
+					Expect(pod.Spec.EphemeralContainers[0].SecurityContext.RunAsNonRoot).ShouldNot(HaveValue(Equal(true)))
+				})
+			})
+	*/
+})

--- a/hooks/mutators/force_run_as_non_root.go
+++ b/hooks/mutators/force_run_as_non_root.go
@@ -17,7 +17,7 @@ func (m ForceRunAsNonRoot) Mutate(ctx context.Context, pod *corev1.Pod) bool {
 			sc = &corev1.SecurityContext{}
 		}
 		if sc.RunAsNonRoot == nil && sc.RunAsUser == nil {
-			sc.RunAsNonRoot = pointer.BoolPtr(true)
+			sc.RunAsNonRoot = pointer.Bool(true)
 			updated = true
 		}
 		pod.Spec.Containers[i].SecurityContext = sc
@@ -28,10 +28,26 @@ func (m ForceRunAsNonRoot) Mutate(ctx context.Context, pod *corev1.Pod) bool {
 			sc = &corev1.SecurityContext{}
 		}
 		if sc.RunAsNonRoot == nil && sc.RunAsUser == nil {
-			sc.RunAsNonRoot = pointer.BoolPtr(true)
+			sc.RunAsNonRoot = pointer.Bool(true)
 			updated = true
 		}
 		pod.Spec.InitContainers[i].SecurityContext = sc
 	}
+
+	// runAsNonRoot of an ephemeral container will not be mutated until the following issue is completed.
+	// https://github.com/kubernetes/kubectl/issues/1108
+	/*
+		for i, co := range pod.Spec.EphemeralContainers {
+			sc := co.SecurityContext
+			if sc == nil {
+				sc = &corev1.SecurityContext{}
+			}
+			if sc.RunAsNonRoot == nil && sc.RunAsUser == nil {
+				sc.RunAsNonRoot = pointer.Bool(true)
+				updated = true
+			}
+			pod.Spec.EphemeralContainers[i].SecurityContext = sc
+		}
+	*/
 	return updated
 }

--- a/hooks/testdata/config/hooks.yaml
+++ b/hooks/testdata/config/hooks.yaml
@@ -23,6 +23,14 @@ webhooks:
           - CREATE
         resources:
           - pods
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - pods/ephemeralcontainers
     sideEffects: None
     namespaceSelector:
       matchExpressions:
@@ -51,6 +59,14 @@ webhooks:
           - CREATE
         resources:
           - pods
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - pods/ephemeralcontainers
     sideEffects: None
     namespaceSelector:
       matchExpressions:
@@ -78,6 +94,14 @@ webhooks:
           - CREATE
         resources:
           - pods
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - pods/ephemeralcontainers
     sideEffects: None
     namespaceSelector:
       matchExpressions:
@@ -110,6 +134,14 @@ webhooks:
           - CREATE
         resources:
           - pods
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - pods/ephemeralcontainers
     sideEffects: None
     namespaceSelector:
       matchExpressions:
@@ -137,6 +169,14 @@ webhooks:
           - CREATE
         resources:
           - pods
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - pods/ephemeralcontainers
     sideEffects: None
     namespaceSelector:
       matchExpressions:
@@ -163,6 +203,14 @@ webhooks:
           - CREATE
         resources:
           - pods
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - pods/ephemeralcontainers
     sideEffects: None
     namespaceSelector:
       matchExpressions:

--- a/hooks/testdata/config/mutating.yaml
+++ b/hooks/testdata/config/mutating.yaml
@@ -22,6 +22,14 @@ webhooks:
           - CREATE
         resources:
           - pods
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - pods/ephemeralcontainers
     sideEffects: None
     namespaceSelector:
       matchExpressions:
@@ -54,6 +62,14 @@ webhooks:
           - CREATE
         resources:
           - pods
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - pods/ephemeralcontainers
     sideEffects: None
     namespaceSelector:
       matchExpressions:

--- a/hooks/validators/deny_host_ports.go
+++ b/hooks/validators/deny_host_ports.go
@@ -62,5 +62,10 @@ func (v DenyHostPorts) Validate(ctx context.Context, pod *corev1.Pod) field.Erro
 			}
 		}
 	}
+
+	// NOTE:
+	// It is not necessary to validate ephemeral containers' port.
+	// Ports are not allowed for ephemeral containers.
+	// https://github.com/kubernetes/api/blob/be233f856791f6954ea04ab777edfa3d3627ea22/core/v1/types.go#L3723
 	return errs
 }

--- a/hooks/validators/deny_privileged_containers.go
+++ b/hooks/validators/deny_privileged_containers.go
@@ -34,7 +34,7 @@ func (v DenyPrivilegedContainers) Validate(ctx context.Context, pod *corev1.Pod)
 		}
 	}
 
-	pp = p.Child("ephemeralContainer")
+	pp = p.Child("ephemeralContainers")
 	for i, co := range pod.Spec.EphemeralContainers {
 		if co.SecurityContext == nil || co.SecurityContext.Privileged == nil {
 			continue

--- a/hooks/validators/deny_privileged_containers.go
+++ b/hooks/validators/deny_privileged_containers.go
@@ -33,5 +33,15 @@ func (v DenyPrivilegedContainers) Validate(ctx context.Context, pod *corev1.Pod)
 			errs = append(errs, field.Forbidden(pp.Index(i).Child("securityContext", "privileged"), "Privileged containers are not allowed"))
 		}
 	}
+
+	pp = p.Child("ephemeralContainer")
+	for i, co := range pod.Spec.EphemeralContainers {
+		if co.SecurityContext == nil || co.SecurityContext.Privileged == nil {
+			continue
+		}
+		if *co.SecurityContext.Privileged {
+			errs = append(errs, field.Forbidden(pp.Index(i).Child("securityContext", "privileged"), "Privileged containers are not allowed"))
+		}
+	}
 	return errs
 }

--- a/hooks/validators/deny_privileged_escalation.go
+++ b/hooks/validators/deny_privileged_escalation.go
@@ -35,5 +35,16 @@ func (v DenyPrivilegeEscalation) Validate(ctx context.Context, pod *corev1.Pod) 
 			errs = append(errs, field.Forbidden(pp.Index(i).Child("securityContext", "allowPrivilegeEscalation"), "Allowing privilege escalation for containers is not allowed"))
 		}
 	}
+
+	pp = p.Child("ephemeralContainers")
+	for i, co := range pod.Spec.EphemeralContainers {
+		if co.SecurityContext == nil || co.SecurityContext.AllowPrivilegeEscalation == nil {
+			continue
+		}
+		escalation := *co.SecurityContext.AllowPrivilegeEscalation
+		if escalation {
+			errs = append(errs, field.Forbidden(pp.Index(i).Child("securityContext", "allowPrivilegeEscalation"), "Allowing privilege escalation for containers is not allowed"))
+		}
+	}
 	return errs
 }

--- a/hooks/validators/deny_root_groups.go
+++ b/hooks/validators/deny_root_groups.go
@@ -48,5 +48,15 @@ func (v DenyRootGroups) Validate(ctx context.Context, pod *corev1.Pod) field.Err
 			errs = append(errs, field.Forbidden(pp.Index(i).Child("securityContext", "runAsGroup"), "Running with the root GID is forbidden"))
 		}
 	}
+
+	pp = p.Child("ephemeralContainers")
+	for i, co := range pod.Spec.EphemeralContainers {
+		if co.SecurityContext == nil {
+			continue
+		}
+		if co.SecurityContext.RunAsGroup != nil && *co.SecurityContext.RunAsGroup == 0 {
+			errs = append(errs, field.Forbidden(pp.Index(i).Child("securityContext", "runAsGroup"), "Running with the root GID is forbidden"))
+		}
+	}
 	return errs
 }

--- a/hooks/validators/deny_run_as_root.go
+++ b/hooks/validators/deny_run_as_root.go
@@ -51,6 +51,23 @@ func (v DenyRunAsRoot) Validate(ctx context.Context, pod *corev1.Pod) field.Erro
 			errs = append(errs, err)
 		}
 	}
+
+	// runAsNonRoot of an ephemeral container will not be validated until the following issue is completed.
+	// https://github.com/kubernetes/kubectl/issues/1108
+	/*
+		pp = p.Child("ephemeralContainers")
+		for i, co := range pod.Spec.EphemeralContainers {
+			if co.SecurityContext == nil || (co.SecurityContext.RunAsNonRoot == nil && co.SecurityContext.RunAsUser == nil) {
+				allContainersAllowed = false
+				continue
+			}
+			if err := validateRunUser(pp.Index(i).Child("securityContext"), co.SecurityContext.RunAsNonRoot, co.SecurityContext.RunAsUser); err != nil {
+				allContainersAllowed = false
+				errs = append(errs, err)
+			}
+		}
+	*/
+
 	if allContainersAllowed {
 		return errs
 	}

--- a/hooks/validators/deny_unsafe_capabilities.go
+++ b/hooks/validators/deny_unsafe_capabilities.go
@@ -71,5 +71,17 @@ func (v DenyUnsafeCapabilities) Validate(ctx context.Context, pod *corev1.Pod) f
 		}
 	}
 
+	pp = p.Child("ephemeralContainers")
+	for i, co := range pod.Spec.EphemeralContainers {
+		if co.SecurityContext == nil || co.SecurityContext.Capabilities == nil {
+			continue
+		}
+		for j, add := range co.SecurityContext.Capabilities.Add {
+			if _, ok := v.allowedCapabilities[string(add)]; !ok {
+				errs = append(errs, field.Forbidden(pp.Index(i).Child("securityContext", "capabilities", "add").Index(j), fmt.Sprintf("Adding capability %s is not allowed", add)))
+			}
+		}
+	}
+
 	return errs
 }

--- a/hooks/validators/deny_unsafe_procmount.go
+++ b/hooks/validators/deny_unsafe_procmount.go
@@ -37,5 +37,16 @@ func (v DenyUnsafeProcMount) Validate(ctx context.Context, pod *corev1.Pod) fiel
 		}
 	}
 
+	pp = p.Child("ephemeralContainers")
+	for i, co := range pod.Spec.EphemeralContainers {
+		if co.SecurityContext == nil || co.SecurityContext.ProcMount == nil {
+			continue
+		}
+		proc := *co.SecurityContext.ProcMount
+		if proc != corev1.DefaultProcMount {
+			errs = append(errs, field.Forbidden(pp.Index(i).Child("securityContext", "procMount"), fmt.Sprintf("ProcMountType %s is not allowed", proc)))
+		}
+	}
+
 	return errs
 }

--- a/hooks/validators/deny_unsafe_seccomp.go
+++ b/hooks/validators/deny_unsafe_seccomp.go
@@ -39,5 +39,15 @@ func (v DenyUnsafeSeccomp) Validate(ctx context.Context, pod *corev1.Pod) field.
 		}
 	}
 
+	pp = p.Child("ephemeralContainers")
+	for i, co := range pod.Spec.EphemeralContainers {
+		if co.SecurityContext == nil || co.SecurityContext.SeccompProfile == nil {
+			continue
+		}
+		if co.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+			errs = append(errs, field.Forbidden(pp.Index(i).Child("securityContext", "seccompProfile", "type"), fmt.Sprintf("%s is not an allowed seccomp profile", co.SecurityContext.SeccompProfile.Type)))
+		}
+	}
+
 	return errs
 }

--- a/hooks/validators/deny_unsafe_selinux.go
+++ b/hooks/validators/deny_unsafe_selinux.go
@@ -32,5 +32,12 @@ func (v DenyUnsafeSELinux) Validate(ctx context.Context, pod *corev1.Pod) field.
 		}
 	}
 
+	pp = p.Child("ephemeralContainers")
+	for i, co := range pod.Spec.EphemeralContainers {
+		if co.SecurityContext != nil && co.SecurityContext.SELinuxOptions != nil {
+			errs = append(errs, field.Forbidden(pp.Index(i).Child("securityContext", "selinuxOptions"), "Setting custom SELinux options is not allowed"))
+		}
+	}
+
 	return errs
 }


### PR DESCRIPTION
Current pod-security-admission does not validate and mutate EphemeralContainers.
This PR supports EphemeralContainers as the webhook targets.

However, there is a limitation. Please check readme.md for detail.

Signed-off-by: zoetrope <a.ikezoe@gmail.com>