### PR TITLE
Allow net.ipv4.ip_unprivileged_port_start

### DIFF
--- a/hooks/testdata/restricted/safe-sysctl.yaml
+++ b/hooks/testdata/restricted/safe-sysctl.yaml
@@ -10,6 +10,8 @@ spec:
         value: "0"
       - name: net.ipv4.ping_group_range
         value: "0 10000"
+      - name: net.ipv4.ip_unprivileged_port_start
+        value: "0"
   containers:
     - name: ubuntu
       image: quay.io/cybozu/ubuntu

--- a/hooks/validators/deny_unsafe_sysctls.go
+++ b/hooks/validators/deny_unsafe_sysctls.go
@@ -9,10 +9,11 @@ import (
 )
 
 var allowedSysctls = map[string]struct{}{
-	"kernel.shm_rmid_forced":       {},
-	"net.ipv4.ip_local_port_range": {},
-	"net.ipv4.tcp_syncookies":      {},
-	"net.ipv4.ping_group_range":    {},
+	"kernel.shm_rmid_forced":              {},
+	"net.ipv4.ip_local_port_range":        {},
+	"net.ipv4.tcp_syncookies":             {},
+	"net.ipv4.ping_group_range":           {},
+	"net.ipv4.ip_unprivileged_port_start": {},
 }
 
 // DenyUnsafeSysctls is a Validator that denies usage of unsafe sysctls


### PR DESCRIPTION
Since Kubernetes v1.22, `net.ipv4.ip_unprivileged_port_start` is marked as a safe systl.

https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/
https://github.com/kubernetes/kubernetes/pull/103326

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>