### PR TITLE
increase the default number of replicas

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
@@ -63,3 +63,14 @@ spec:
         - name: config
           configMap:
             name: pod-security-admission-config
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager


### PR DESCRIPTION
If PSA Pods are gone, no new Pods can be created. Multiple replicas and a PDB are required.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>