### PR TITLE
Add an option to allow hostpath only when mounted as read-only

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,9 +32,10 @@ SecurityProfile has these fields:
 
 #### AllowedHostPath
 
-| Name       | Type   | Description                   |
-| ---------- | ------ | ----------------------------- |
-| pathPrefix | string | The path prefix to be allowed |
+| Name       | Type   | Description                                                    |
+|------------|--------|----------------------------------------------------------------|
+| pathPrefix | string | The path prefix to be allowed                                  |
+| readOnly   | bool   | If `readOnly` is true, this path can only be mounted read-only |
 
 ### PortRange
 

--- a/hooks/suite_test.go
+++ b/hooks/suite_test.go
@@ -143,6 +143,10 @@ var _ = BeforeSuite(func() {
 			{
 				PathPrefix: "/etc/hos", // not "host"
 			},
+			{
+				PathPrefix: "/opt/bin",
+				ReadOnly:   true,
+			},
 		},
 		AllowedHostPorts: []validators.PortRange{
 			{

--- a/hooks/testdata/hostpath-violation/host-path6.yaml
+++ b/hooks/testdata/hostpath-violation/host-path6.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: host-path6
+  annotations:
+    test.pod-security.cybozu.com/message: "denied the request: spec.volumes[0]: Forbidden: HostPath is allowed to be used only as read-only"
+spec:
+  securityContext:
+    runAsNonRoot: true
+  containers:
+    - name: ubuntu
+      image: ghcr.io/cybozu/ubuntu
+      volumeMounts:
+        - mountPath: /mnt
+          name: host
+  volumes:
+    - name: host
+      hostPath:
+        path: /opt/bin

--- a/hooks/testdata/hostpath/host-path5.yaml
+++ b/hooks/testdata/hostpath/host-path5.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: host-path5
+  annotations:
+    test.pod-security.cybozu.com/message: "denied the request: spec.volumes[0]: Forbidden: HostPath is not allowed to be used"
+spec:
+  securityContext:
+    runAsNonRoot: true
+  containers:
+    - name: ubuntu
+      image: ghcr.io/cybozu/ubuntu
+      volumeMounts:
+        - mountPath: /mnt
+          name: host
+          readOnly: true
+  volumes:
+    - name: host
+      hostPath:
+        path: /opt/bin

--- a/hooks/validate_pod_test.go
+++ b/hooks/validate_pod_test.go
@@ -47,6 +47,7 @@ var _ = Describe("validate Pod webhook", func() {
 	It("should deny privileged pods in hostpath namespace", func() {
 		validatePod(filepath.Join("testdata", "privileged"), "hostpath", false)
 		validatePod(filepath.Join("testdata", "hostpath"), "hostpath", true)
+		validatePod(filepath.Join("testdata", "hostpath-violation"), "hostpath", false)
 		validatePod(filepath.Join("testdata", "baseline"), "hostpath", true)
 		validatePod(filepath.Join("testdata", "restricted"), "hostpath", true)
 	})

--- a/hooks/validators/deny_host_path_volumes.go
+++ b/hooks/validators/deny_host_path_volumes.go
@@ -11,6 +11,7 @@ import (
 
 type AllowedHostPath struct {
 	PathPrefix string `json:"pathPrefix"`
+	ReadOnly   bool   `json:"readOnly"`
 }
 
 // DenyHostPathVolumes is a Validator that denies usage of HostPath volumes
@@ -26,18 +27,48 @@ func (v DenyHostPathVolumes) Validate(ctx context.Context, pod *corev1.Pod) fiel
 	p := field.NewPath("spec").Child("volumes")
 	var errs field.ErrorList
 
-volume_for:
 	for i, vol := range pod.Spec.Volumes {
 		if vol.HostPath == nil {
 			continue
 		}
-		pathstr := vol.HostPath.Path
-		for _, allowed := range v.allowedHostPaths {
-			if strings.HasPrefix(pathstr, allowed.PathPrefix) && (len(pathstr) == len(allowed.PathPrefix) || []rune(pathstr)[len(allowed.PathPrefix)] == filepath.Separator) {
-				continue volume_for
+		allowed, readonly := v.allowedPath(vol.HostPath.Path)
+		if !allowed {
+			errs = append(errs, field.Forbidden(p.Index(i), "HostPath is not allowed to be used"))
+			continue
+		}
+
+		if readonly {
+			for _, container := range pod.Spec.Containers {
+				for _, mount := range container.VolumeMounts {
+					if mount.Name == vol.Name && !mount.ReadOnly {
+						errs = append(errs, field.Forbidden(p.Index(i), "HostPath is allowed to be used only as read-only"))
+					}
+				}
+			}
+			for _, container := range pod.Spec.InitContainers {
+				for _, mount := range container.VolumeMounts {
+					if mount.Name == vol.Name && !mount.ReadOnly {
+						errs = append(errs, field.Forbidden(p.Index(i), "HostPath is allowed to be used only as read-only"))
+					}
+				}
+			}
+			for _, container := range pod.Spec.EphemeralContainers {
+				for _, mount := range container.VolumeMounts {
+					if mount.Name == vol.Name && !mount.ReadOnly {
+						errs = append(errs, field.Forbidden(p.Index(i), "HostPath is allowed to be used only as read-only"))
+					}
+				}
 			}
 		}
-		errs = append(errs, field.Forbidden(p.Index(i), "HostPath is not allowed to be used"))
 	}
 	return errs
+}
+
+func (v DenyHostPathVolumes) allowedPath(path string) (bool, bool) {
+	for _, allowed := range v.allowedHostPaths {
+		if strings.HasPrefix(path, allowed.PathPrefix) && (len(path) == len(allowed.PathPrefix) || []rune(path)[len(allowed.PathPrefix)] == filepath.Separator) {
+			return true, allowed.ReadOnly
+		}
+	}
+	return false, false
 }


### PR DESCRIPTION
The following setting allows `/opt/bin` to be mounted **only** in read-only mode:

```yaml
- name: baseline
  allowedHostPaths:
    - pathPrefix: /opt/bin
      readOnly: true
```
