### PR TITLE
Align seccomp validation with Kubernetes PSS Baseline policy

### DIFF
--- a/charts/pod-security-admission/values.yaml
+++ b/charts/pod-security-admission/values.yaml
@@ -22,7 +22,6 @@ podSecurityAdmissionConfig:
       allowPrivilegeEscalation: true
       runAsRoot: true
       rootGroups: true
-      seccomp: true
     - name: restricted
       forceRunAsNonRoot: true
 webhookService:

--- a/config/manager/config.yaml
+++ b/config/manager/config.yaml
@@ -3,6 +3,5 @@
   allowPrivilegeEscalation: true
   runAsRoot: true
   rootGroups: true
-  seccomp: true
 - name: restricted
   forceRunAsNonRoot: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,6 @@ The profile describes only the allowed items. A false or no description indicate
   allowPrivilegeEscalation: true
   runAsRoot: true
   rootGroups: true
-  seccomp: true
 - name: restricted
   forceRunAsNonRoot: true
 ```
@@ -79,7 +78,6 @@ The following `Baseline` profile allows hostNamespaces, to add `SYSLOG` and `NET
   allowPrivilegeEscalation: true
   rootGroups: true
   runAsRoot: true
-  seccomp: true
 - name: restricted
   forceRunAsNonRoot: true
 ```

--- a/hooks/ephemeral_container_test.go
+++ b/hooks/ephemeral_container_test.go
@@ -139,12 +139,11 @@ spec:
 				SecurityContext: &corev1.SecurityContext{
 					RunAsNonRoot: ptr.To(true),
 					SeccompProfile: &corev1.SeccompProfile{
-						Type:             corev1.SeccompProfileTypeLocalhost,
-						LocalhostProfile: ptr.To("profiles/audit.json"),
+						Type: corev1.SeccompProfileTypeUnconfined,
 					},
 				},
 			},
-		}, false, "denied the request: spec.ephemeralContainers[0].securityContext.seccompProfile.type: Forbidden: Localhost is not an allowed seccomp profile"),
+		}, false, "denied the request: spec.ephemeralContainers[0].securityContext.seccompProfile.type: Forbidden: Unconfined is not an allowed seccomp profile"),
 		Entry("UnsafeSELinux Ephemeral Container", "restricted", "test-unsafe-selinux-ec", corev1.EphemeralContainer{
 			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
 				Name:  "debug",

--- a/hooks/suite_test.go
+++ b/hooks/suite_test.go
@@ -125,7 +125,6 @@ var _ = BeforeSuite(func() {
 			},
 		},
 		RootGroups:               true,
-		Seccomp:                  true,
 		AllowPrivilegeEscalation: true,
 		RunAsRoot:                true,
 	}
@@ -155,7 +154,6 @@ var _ = BeforeSuite(func() {
 			},
 		},
 		RootGroups:               true,
-		Seccomp:                  true,
 		AllowPrivilegeEscalation: true,
 		RunAsRoot:                true,
 	}

--- a/hooks/testdata/validating/seccomp2.yaml
+++ b/hooks/testdata/validating/seccomp2.yaml
@@ -3,10 +3,10 @@ kind: Pod
 metadata:
   name: seccomp2
   annotations:
-    expected.pod-security.cybozu.com/baseline: ""
-    expected.pod-security.cybozu.com/hostpath: ""
+    expected.pod-security.cybozu.com/baseline: "denied the request: spec.containers[0].securityContext.seccompProfile.type: Forbidden: Unconfined is not an allowed seccomp profile"
+    expected.pod-security.cybozu.com/hostpath: "denied the request: spec.containers[0].securityContext.seccompProfile.type: Forbidden: Unconfined is not an allowed seccomp profile"
     expected.pod-security.cybozu.com/privileged: ""
-    expected.pod-security.cybozu.com/restricted: "denied the request: spec.containers[0].securityContext.seccompProfile.type: Forbidden: Localhost is not an allowed seccomp profile"
+    expected.pod-security.cybozu.com/restricted: "denied the request: spec.containers[0].securityContext.seccompProfile.type: Forbidden: Unconfined is not an allowed seccomp profile"
 spec:
   securityContext:
     runAsNonRoot: true
@@ -15,5 +15,4 @@ spec:
       image: ghcr.io/cybozu/ubuntu
       securityContext:
         seccompProfile:
-          type: "Localhost"
-          localhostProfile: profiles/audit.json
+          type: "Unconfined"

--- a/hooks/testdata/validating/seccomp3.yaml
+++ b/hooks/testdata/validating/seccomp3.yaml
@@ -3,10 +3,10 @@ kind: Pod
 metadata:
   name: seccomp3
   annotations:
-    expected.pod-security.cybozu.com/baseline: ""
-    expected.pod-security.cybozu.com/hostpath: ""
+    expected.pod-security.cybozu.com/baseline: "denied the request: spec.initContainers[0].securityContext.seccompProfile.type: Forbidden: Unconfined is not an allowed seccomp profile"
+    expected.pod-security.cybozu.com/hostpath: "denied the request: spec.initContainers[0].securityContext.seccompProfile.type: Forbidden: Unconfined is not an allowed seccomp profile"
     expected.pod-security.cybozu.com/privileged: ""
-    expected.pod-security.cybozu.com/restricted: "denied the request: spec.initContainers[0].securityContext.seccompProfile.type: Forbidden: Localhost is not an allowed seccomp profile"
+    expected.pod-security.cybozu.com/restricted: "denied the request: spec.initContainers[0].securityContext.seccompProfile.type: Forbidden: Unconfined is not an allowed seccomp profile"
 spec:
   securityContext:
     runAsNonRoot: true
@@ -18,5 +18,4 @@ spec:
       image: ghcr.io/cybozu/ubuntu-debug
       securityContext:
         seccompProfile:
-          type: "Localhost"
-          localhostProfile: profiles/audit.json
+          type: "Unconfined"

--- a/hooks/testdata/validating/seccomp4.yaml
+++ b/hooks/testdata/validating/seccomp4.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccomp4
+  annotations:
+    expected.pod-security.cybozu.com/baseline: "denied the request: spec.securityContext.seccompProfile.type: Forbidden: Unconfined is not an allowed seccomp profile"
+    expected.pod-security.cybozu.com/hostpath: "denied the request: spec.securityContext.seccompProfile.type: Forbidden: Unconfined is not an allowed seccomp profile"
+    expected.pod-security.cybozu.com/privileged: ""
+    expected.pod-security.cybozu.com/restricted: "denied the request: spec.securityContext.seccompProfile.type: Forbidden: Unconfined is not an allowed seccomp profile"
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: "Unconfined"
+  containers:
+    - name: ubuntu
+      image: ghcr.io/cybozu/ubuntu

--- a/hooks/testdata/validating/seccomp5.yaml
+++ b/hooks/testdata/validating/seccomp5.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: seccomp1
+  name: seccomp5
   annotations:
     expected.pod-security.cybozu.com/baseline: ""
     expected.pod-security.cybozu.com/hostpath: ""
@@ -10,9 +10,6 @@ metadata:
 spec:
   securityContext:
     runAsNonRoot: true
-    seccompProfile:
-      type: "Localhost"
-      localhostProfile: profiles/audit.json
   containers:
     - name: ubuntu
       image: ghcr.io/cybozu/ubuntu

--- a/hooks/validators/deny_unsafe_seccomp.go
+++ b/hooks/validators/deny_unsafe_seccomp.go
@@ -15,8 +15,10 @@ func (v DenyUnsafeSeccomp) Validate(ctx context.Context, pod *corev1.Pod) field.
 	p := field.NewPath("spec")
 	var errs field.ErrorList
 
-	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.SeccompProfile != nil && pod.Spec.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
-		errs = append(errs, field.Forbidden(p.Child("securityContext", "seccompProfile", "type"), fmt.Sprintf("%s is not an allowed seccomp profile", pod.Spec.SecurityContext.SeccompProfile.Type)))
+	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.SeccompProfile != nil {
+		if !validSeccomp(pod.Spec.SecurityContext.SeccompProfile.Type) {
+			errs = append(errs, field.Forbidden(p.Child("securityContext", "seccompProfile", "type"), fmt.Sprintf("%s is not an allowed seccomp profile", pod.Spec.SecurityContext.SeccompProfile.Type)))
+		}
 	}
 
 	pp := p.Child("containers")
@@ -24,7 +26,7 @@ func (v DenyUnsafeSeccomp) Validate(ctx context.Context, pod *corev1.Pod) field.
 		if co.SecurityContext == nil || co.SecurityContext.SeccompProfile == nil {
 			continue
 		}
-		if co.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		if !validSeccomp(co.SecurityContext.SeccompProfile.Type) {
 			errs = append(errs, field.Forbidden(pp.Index(i).Child("securityContext", "seccompProfile", "type"), fmt.Sprintf("%s is not an allowed seccomp profile", co.SecurityContext.SeccompProfile.Type)))
 		}
 	}
@@ -34,7 +36,7 @@ func (v DenyUnsafeSeccomp) Validate(ctx context.Context, pod *corev1.Pod) field.
 		if co.SecurityContext == nil || co.SecurityContext.SeccompProfile == nil {
 			continue
 		}
-		if co.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		if !validSeccomp(co.SecurityContext.SeccompProfile.Type) {
 			errs = append(errs, field.Forbidden(pp.Index(i).Child("securityContext", "seccompProfile", "type"), fmt.Sprintf("%s is not an allowed seccomp profile", co.SecurityContext.SeccompProfile.Type)))
 		}
 	}
@@ -44,10 +46,15 @@ func (v DenyUnsafeSeccomp) Validate(ctx context.Context, pod *corev1.Pod) field.
 		if co.SecurityContext == nil || co.SecurityContext.SeccompProfile == nil {
 			continue
 		}
-		if co.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		if !validSeccomp(co.SecurityContext.SeccompProfile.Type) {
 			errs = append(errs, field.Forbidden(pp.Index(i).Child("securityContext", "seccompProfile", "type"), fmt.Sprintf("%s is not an allowed seccomp profile", co.SecurityContext.SeccompProfile.Type)))
 		}
 	}
 
 	return errs
+}
+
+func validSeccomp(t corev1.SeccompProfileType) bool {
+	return t == corev1.SeccompProfileTypeLocalhost ||
+		t == corev1.SeccompProfileTypeRuntimeDefault
 }


### PR DESCRIPTION
## Summary

This PR updates the seccomp profile validation in DenyUnsafeSeccomp to align with the [Kubernetes Pod Security Standards (PSS) Baseline policy](https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline).

## Changes

- Expanded allowed seccomp types: Previously, only RuntimeDefault was permitted. Now Localhost is also allowed, matching the upstream PSS Baseline spec which permits RuntimeDefault and Localhost.

- Removed `seccomp: true` flag from Baseline profile config in helm chart